### PR TITLE
🤖 Refactor : 코드 리팩토링

### DIFF
--- a/src/main/java/com/concurrency/jpa/customer/Product/ProductService.java
+++ b/src/main/java/com/concurrency/jpa/customer/Product/ProductService.java
@@ -9,6 +9,7 @@ import java.util.Map;
 public interface ProductService {
     List<ActualProduct> findActualProductsByOrder(Long orderId);
     List<ActualProduct> findActualProducts(Long coreProductId, ActualStatus actualStatus, Long stock);
+
     List<ActualProduct> concatActualProductList(Map<Long, Long> coreProducts);
     void updateCoreProductsStock(Map<Long, Long> requireProducts);
     long subtractCoreProductStock(Long coreProductId, Long reqStock);

--- a/src/main/java/com/concurrency/jpa/customer/Product/ProductServiceImpl.java
+++ b/src/main/java/com/concurrency/jpa/customer/Product/ProductServiceImpl.java
@@ -77,8 +77,9 @@ public class ProductServiceImpl implements ProductService{
         return coreProduct.addStrock(-reqStock);
     }
 
-    @Transactional(isolation = Isolation.SERIALIZABLE)
+    @Transactional
     public long subtractCoreProductStockPessimistic(Long coreProductId, Long reqStock){
+        System.out.println("핵심 상품 쿼리");
         CoreProduct coreProduct = coreProductRepository.findByIdPessimistic(coreProductId)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.FAIL));
         long stock = coreProduct.getStock();

--- a/src/main/java/com/concurrency/jpa/customer/Product/dto/OrderCoreProductStockDto.java
+++ b/src/main/java/com/concurrency/jpa/customer/Product/dto/OrderCoreProductStockDto.java
@@ -1,0 +1,9 @@
+package com.concurrency.jpa.customer.Product.dto;
+
+import lombok.Value;
+
+@Value
+public class OrderCoreProductStockDto {
+    Long coreProductId;
+    Long reduceStock;
+}

--- a/src/main/java/com/concurrency/jpa/customer/Product/entity/ActualProduct.java
+++ b/src/main/java/com/concurrency/jpa/customer/Product/entity/ActualProduct.java
@@ -19,12 +19,13 @@ public class ActualProduct {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Getter
     @Enumerated(EnumType.STRING)
     @Column(name = "actual_status", columnDefinition = "varchar(255)")
     private ActualStatus actualStatus;
 
     @Getter
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "core_product_id", nullable = false)
     private CoreProduct coreProduct;
 

--- a/src/main/java/com/concurrency/jpa/customer/order/OrderRepository.java
+++ b/src/main/java/com/concurrency/jpa/customer/order/OrderRepository.java
@@ -1,20 +1,26 @@
 package com.concurrency.jpa.customer.order;
 
+import com.concurrency.jpa.customer.Product.dto.OrderCoreProductStockDto;
+import com.concurrency.jpa.customer.Product.enums.ActualStatus;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface OrderRepository extends
         JpaRepository<Order, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select m from Order m join fetch m.actualProducts a join fetch a.coreProduct c where m.paymentId = :id")
+    @Query("select m from Order m join m.actualProducts a where m.paymentId = :id")
     Optional<Order> findByPaymentIdWithFetch(Long id);
 
+    @Query("select new com.concurrency.jpa.customer.Product.dto.OrderCoreProductStockDto(c.id, count(a.id)) " +
+            "from Order o join o.actualProducts a join a.coreProduct c where o.id = :id " +
+            "group by c.id")
+    List<OrderCoreProductStockDto> findCoreProductStockByOrderId(Long id);
     Optional<Order> findByPaymentId(Long id);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@
 
 # Core configuration
 spring.application.name: spring-web-jpa-concurrency
-spring.profiles.active: default, dev, init-sql
+spring.profiles.active: default, dev #, init-sql
 
 # Database configuration
 spring.datasource:
@@ -15,6 +15,11 @@ spring.datasource:
   username: chansol
   password: solsol
   driver-class-name: com.mysql.cj.jdbc.Driver
+
+# Hibernate Cache hit statistics
+hibernate:
+  cache:
+    use_query_cache=true:
 
 # Payment Server url
 payment.server.url: http://localhost:8081 # http://13.125.145.9:8080/


### PR DESCRIPTION
롤백 메서드에서 불필요하게 주문과 유형 상품에 비관적 락을 걸지 않도록 수정
1. 유형 상품과 핵심 상품의 fetch 설정을 Lazy로 설정
2. 주문과 유형 상품만 fetch join으로 한번에 쿼리 그리고 핵심 상품은 비관적 락을 걸어 따로 쿼리 그 결과 락을 무분별하게 사용하지 않고 필요한 곳에만 사용하게함.

## 개요

<!-- 이 PR은 무엇을 하는지 간단히 설명해주세요.
- 새로운 로그인 기능 추가
-->

## 변경 사항

<!-- 이 PR로 인해 어떤 것이 변경되는지 나열해주세요.
- [x] 🐛 Fix : 오류 수정
- [x] ✨ Feat : 새로운 기능
- [x] 🔧 Modify : 위치 변경
- [x] 🤖 Refactor : 코드 리팩토링
- [x] ✅ Test : 테스트 코드 추가
- [x] 💡 Comment : 필요한 주석 추가 및 변경
- [x] 🚚 Chore : 환경설정 변경
- [x] 🎨 Style : 의미 없는 코드 형식 수정
- [x] 🔥 Remove : 삭제
- [x] 📝 Docs : 문서 수정
-->

## 추가 정보

<!-- 이 PR에 대해 필요한 후속 작업이 있다면 추가해주세요.
- [ ] 로그인 페이지 추가 필요
- [ ] 로그인 API 연결 필요
-->

### 관련 이슈

<!--
문제를 해결한다면 Fix 또는 Resolve
일반적으로는 Closes #123
-->


